### PR TITLE
chore(ci): replace custom image with stock runner image for simple jobs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 #[net]
 #git-fetch-with-cli = true
 
-[build]
-rustc-wrapper = "sccache"
+# [build]
+# rustc-wrapper = "sccache"
 
 # Use lld linker for all platforms except android and ios (does not find all libraries, but we let the NDK decide the linking stuff instead)
 # Make sure version is same as installed in the devcontainer!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Check format
+        run: cargo fmt --check
+
+  unused-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-machete
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete
+
+      - name: Check for unused dependencies
+        run: cargo machete
+
+  audit-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+
+      - name: Audit dependencies
+        run: cargo audit --color always
+
+  lint-clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,22 +67,8 @@ jobs:
         with:
           version: "21.12"
 
-      - name: Check format
-        run: cargo fmt --check
-
-      - name: Install cargo-machete, cargo-audit
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-machete,cargo-audit
-
-      - name: Check for unused dependencies
-        run: cargo machete
-
       - name: Check for clippy warnings
         run: cargo clippy --all-targets --all-features --color always -- -D warnings
-
-      - name: Audit dependencies
-        run: cargo audit --color always
 
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 # cancel the job if a newer pipeline starts for the same MR or branch
 concurrency:
@@ -21,45 +19,64 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: dell
-    container:
-      image: ${{ vars.DEVCONTAINER_IMAGE }}:${{ vars.DEVCONTAINER_TAG }}
-      credentials:
-        username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+
       - name: Check format
         run: cargo fmt --check
+
+      - name: Install cargo-machete, cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-machete,cargo-audit
+
       - name: Check for unused dependencies
         run: cargo machete
+
       - name: Check for clippy warnings
         run: cargo clippy --all-targets --all-features --color always -- -D warnings
-      # - name: Audit dependencies
-      #   run: cargo audit --color always
+
+      - name: Audit dependencies
+        run: cargo audit --color always
 
   unit-tests:
-    runs-on: dell
-    container:
-      image: ${{ vars.DEVCONTAINER_IMAGE }}:${{ vars.DEVCONTAINER_TAG }}
-      credentials:
-        username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    runs-on: ubuntu-latest
     env:
       VIVISWAP_ENV: testing
     steps:
       - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Install nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
       - name: Run unit tests
         run: cargo llvm-cov nextest --profile ci --locked --lib --workspace --no-fail-fast --all-features --cobertura --output-path cobertura.xml --exclude cryptpay-sdk-jni --exclude cryptpay-sdk-swift --exclude cryptpay-sdk-wasm --ignore-filename-regex "sdk/bindings/|api_types/|.*/error\.rs"
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: ${{ github.workspace }}/target/nextest/ci/junit.xml
+
       - name: Publish Coverage
         uses: 5monkeys/cobertura-action@master
         with:
@@ -67,16 +84,31 @@ jobs:
           minimum_coverage: 75
 
   build-sdk-wasm:
-    runs-on: dell
-    container:
-      image: ${{ vars.DEVCONTAINER_IMAGE }}:${{ vars.DEVCONTAINER_TAG }}
-      credentials:
-        username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Use Node.js v20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          # cache: 'pnpm'
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
       - name: Build wasm sdk
         run: |
           cd sdk/bindings/wasm
@@ -87,6 +119,7 @@ jobs:
           wasm-pack build --release --scope eto
           pnpm install
           pnpm build
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -105,10 +138,11 @@ jobs:
         password: ${{ secrets.ARTIFACTORY_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - uses: Swatinem/rust-cache@v2
+
       - name: Build android sdk
         run: cd sdk/bindings/android && make bundle
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -141,30 +175,29 @@ jobs:
           overwrite: true
 
   android-bindings-tests:
-    runs-on: dell
-    needs: build-sdk-android
-    container:
-      image: ${{ vars.DEVCONTAINER_IMAGE }}:${{ vars.DEVCONTAINER_TAG }}
-      credentials:
-        username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+
       - name: Run android bindings tests
         run: cd sdk/bindings/android/tests && gradle test
 
   jnigen-integration-tests:
-    runs-on: dell
-    container:
-      image: ${{ vars.DEVCONTAINER_IMAGE }}:${{ vars.DEVCONTAINER_TAG }}
-      credentials:
-        username: ${{ secrets.ARTIFACTORY_USERNAME }}
-        password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+
       - name: Run jnigen integration test
         run: cd tools/jnigen-integration-test && gradle test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ repository = "https://github.com/ETOSPHERES-Labs/cawaena-sdk"
 # Therefore we can allow this lint for now, and simply remove it whenever we need to actually see them.
 deprecated = "allow"
 
+# used for the wasm bindings tests
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+
 [workspace.lints.clippy]
 # With these two, we avoid panicking behavior in our code.
 # In some places where panicking is desired, such as in tests or in the `main.rs` files,


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

We are currently using our self-hosted `dell` runner to run all jobs. For some reason, the runner does not pick jobs to run in parallell and thus the CI takes forever. And since the repo is now public, we might as well use the provided github-hosted runners, especially for jobs that are not that heavy.

## Summary

Provide a short summary of changes in this pull request.

- Change all CI jobs to use the public runners, except for `build-sdk-android` and `build-sdk-swift` which still run on `dell` using our custom image. We can consider changing this in the future.
- Breakup the `lint`  job into it's separate components.

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
