### PR TITLE
chore(deps): pin web-sys and js-sys to `v0.3.74` to fix issue with Crypto API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ version = "0.14.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
+ "js-sys",
  "log",
  "ring",
  "sdk",
@@ -1362,6 +1363,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]
@@ -2901,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -5583,24 +5585,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
 dependencies = [
  "bumpalo",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -5621,9 +5623,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5631,9 +5633,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5644,12 +5646,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
-dependencies = [
- "unicode-ident",
-]
+checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -5693,9 +5692,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/sdk/bindings/wasm/Cargo.toml
+++ b/sdk/bindings/wasm/Cargo.toml
@@ -52,6 +52,10 @@ wasm-bindgen = { version = "0.2", default-features = false }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 serde_json = { workspace = true }
 
+# Versions >= 0.3.35 causes issues accessing the Crypto API (for rand crate), so pin to working version for now
+web-sys = "=0.3.74"
+js-sys = "=0.3.74"
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 

--- a/sdk/bindings/wasm/Cargo.toml
+++ b/sdk/bindings/wasm/Cargo.toml
@@ -62,4 +62,4 @@ wasm-bindgen-test = "0.3"
 # cargo-machete thinks that `wasm-bindgen-futures` and `ring` are unused, but they are actually needed after
 # the wasm_bindgen macro has been expanded.
 [package.metadata.cargo-machete]
-ignored = ["wasm-bindgen-futures", "ring", "uuid"]
+ignored = ["wasm-bindgen-futures", "ring", "uuid", "web-sys", "js-sys"]


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

Running the wasm examples in node, we get an error "Crypto API not available". After some investigation this was found to be caused by an upgrade of `web-sys` and `js-sys` to `v.0.3.75` (#4 ) . Thus these deps have been pinned / held back to make this work again. Possibly we need to do a minimum reproduction of the error and open an issue upstream, but this does the job for now 🚀 

## Summary

Provide a short summary of changes in this pull request.

- Pin `web-sys` and `js-sys` to `v0.3.74`

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
