### PR TITLE
refactor: remove shimmer support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,13 +108,37 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
       - name: Run unit tests
-        run: cargo llvm-cov nextest --profile ci --locked --lib --workspace --no-fail-fast --all-features --cobertura --output-path cobertura.xml --exclude cryptpay-sdk-jni --exclude cryptpay-sdk-swift --exclude cryptpay-sdk-wasm --ignore-filename-regex "sdk/bindings/|api_types/|.*/error\.rs"
+        run: make unit-tests
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: ${{ github.workspace }}/target/nextest/ci/junit.xml
+
+  unit-tests-coverage:
+    runs-on: ubuntu-latest
+    env:
+      VIVISWAP_ENV: testing
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Install nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      - name: Run unit tests with coverage
+        run: cargo llvm-cov nextest --profile ci --locked --lib --workspace --no-fail-fast --all-features --cobertura --output-path cobertura.xml --exclude cryptpay-sdk-jni --exclude cryptpay-sdk-swift --exclude cryptpay-sdk-wasm --ignore-filename-regex "sdk/bindings/|api_types/|.*/error\.rs"
 
       - name: Publish Coverage
         uses: 5monkeys/cobertura-action@master

--- a/api_types/src/api/generic.rs
+++ b/api_types/src/api/generic.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 pub enum ApiCryptoCurrency {
     /// Iota Crypto Currency
     Iota,
-    /// Shimmer Crypto Currency
-    Smr,
     /// Ethereum Crypto Currency
     Eth,
 }

--- a/api_types/src/api/viviswap/detail.rs
+++ b/api_types/src/api/viviswap/detail.rs
@@ -17,7 +17,6 @@ pub struct PaymentDetail {
 pub enum SwapPaymentDetailKey {
     Sepa,
     Iota,
-    Smr,
     Eth,
 }
 

--- a/sdk/bindings/android/src/lib.rs
+++ b/sdk/bindings/android/src/lib.rs
@@ -89,7 +89,6 @@ mod ffi {
     ///     "storage_path": "/path/to/valid/folder",
     ///     "log_level": "info",
     ///     "node_urls": {
-    ///         "smr": ["https://api.testnet.shimmer.network"],
     ///         "iota": ["<first node url>", "<second node url>"]
     ///     }
     /// }

--- a/sdk/bindings/android/tests/src/main/java/com/etogruppe/examples/utils.java
+++ b/sdk/bindings/android/tests/src/main/java/com/etogruppe/examples/utils.java
@@ -60,7 +60,7 @@ public class utils {
             sdk.refreshAccessToken(access_token);
             System.out.println("retrieved access token");
 
-            sdk.setCurrency("Smr");
+            sdk.setCurrency("Iota");
         } catch (Exception e) {
             throw new RuntimeException("Failed to initialize SDK", e);
         }

--- a/sdk/bindings/android/tests/src/test/java/com/etogruppe/SdkUnitTest.java
+++ b/sdk/bindings/android/tests/src/test/java/com/etogruppe/SdkUnitTest.java
@@ -39,7 +39,7 @@ public class SdkUnitTest {
     private static final String PASSWORD = "StrongP@55word";
     private static final String BACKUP_PASSWORD = "BackupStrongP@55word";
     private static final String AUTH_PROVIDER = "standalone";
-    private static final String CURRENCY = "Smr";
+    private static final String CURRENCY = "Iota";
     private static final String EMAIL = "useremail@gmail.com";
     private static final String TOKEN_HEADER_VALUE = String.format("Bearer %s", token);
     private static final String CASE_ID = "123456789ABC";
@@ -63,17 +63,17 @@ public class SdkUnitTest {
 
             sdk.setConfig("""
                     {
-                    	"backend_url": "http://localhost:1080/api",
-                    	"storage_path": "%s",
-                    	"log_level": "debug",
-                    	"auth_provider": "standalone",
-                    	"node_urls": {
-                    		"smr": ["https://api.testnet.shimmer.network"]
-                    	}
+                        "backend_url": "http://localhost:1080/api",
+                        "storage_path": "%s",
+                        "log_level": "debug",
+                        "auth_provider": "standalone",
+                        "node_urls": {
+                            "iota": ["https://api.testnet.iotaledger.net"]
+                        }
                     }
                     """.formatted(directory.toString()));
 
-            sdk.setCurrency("SMR");
+            sdk.setCurrency("IOTA");
             sdk.refreshAccessToken(token);
         } catch (Exception e) {
             fail(e.getMessage());
@@ -670,7 +670,7 @@ public class SdkUnitTest {
     public void ZHshouldGetPreferredCurrency() throws Exception {
 
         String body = """
-                    {"currency": "Smr"}
+                    {"currency": "Iota"}
                 """;
         wireMockRule.stubFor(get(urlPathEqualTo("/api/user/currency"))
                 .withHeader("Authorization", equalTo(TOKEN_HEADER_VALUE))
@@ -681,7 +681,7 @@ public class SdkUnitTest {
                         .withHeader("Content-Type", "application/json")
                         .withBody(body)));
         String currency = sdk.getPreferredCurrency();
-        assertEquals(currency, "Smr");
+        assertEquals(currency, "Iota");
 
     }
 

--- a/sdk/bindings/swift/README.md
+++ b/sdk/bindings/swift/README.md
@@ -93,7 +93,7 @@ Finally, the `Package.swift` is the actual file that generates the Swift package
   import Foundation
 
   let sdk = CawaenaSdk()
-  try await sdk.setCurrency(Currency.Smr)
+  try await sdk.setCurrency(Currency.Iota)
 ```
 
 ## Running Examples

--- a/sdk/bindings/swift/examples/Sources/utils/utils.swift
+++ b/sdk/bindings/swift/examples/Sources/utils/utils.swift
@@ -55,7 +55,7 @@ public func initSdk(username: String, password: String) async throws -> CawaenaS
   try await sdk.refreshAccessToken(access_token)
   print("retrieved access token")
 
-  try await sdk.setCurrency(Currency.Smr)
+  try await sdk.setCurrency(Currency.Iota)
 
   return sdk
 }

--- a/sdk/bindings/swift/main.swift
+++ b/sdk/bindings/swift/main.swift
@@ -283,7 +283,7 @@ Task {
                 "log_level": "info",
                 "auth_provider": "standalone",
                 "node_urls": {
-                    "smr": ["https://api.testnet.shimmer.network"]
+                    "iota": ["https://api.testnet.iotaledger.net"]
                 }
             }
             """)

--- a/sdk/bindings/swift/src/ffi_functions.rs
+++ b/sdk/bindings/swift/src/ffi_functions.rs
@@ -57,7 +57,6 @@ impl CawaenaSdk {
     ///     "storage_path": "/path/to/valid/folder",
     ///     "log_level": "info",
     ///     "node_urls": {
-    ///         "smr": ["https://api.testnet.shimmer.network"],
     ///         "iota": ["<first node url>", "<second node url>"]
     ///     }
     /// }

--- a/sdk/bindings/swift/src/lib.rs
+++ b/sdk/bindings/swift/src/lib.rs
@@ -208,14 +208,12 @@ pub mod ffi {
 
     pub enum Currency {
         Iota,
-        Smr,
         Eth,
     }
 
     pub enum PreferredCurrency {
         None,
         Iota,
-        Smr,
         Eth,
     }
 

--- a/sdk/bindings/swift/src/type_conversion.rs
+++ b/sdk/bindings/swift/src/type_conversion.rs
@@ -237,7 +237,7 @@ impl From<sdk::types::transactions::WalletTxInfo> for ffi::WalletTxInfo {
     }
 }
 
-convert_enum!(ffi::Currency, sdk::types::currencies::Currency, Iota, Smr, Eth,);
+convert_enum!(ffi::Currency, sdk::types::currencies::Currency, Iota, Eth,);
 
 convert_enum!(
     ffi::OfficialDocumentType,
@@ -278,7 +278,6 @@ impl From<ffi::PreferredCurrency> for Option<sdk::types::currencies::Currency> {
         match value {
             ffi::PreferredCurrency::None => None,
             ffi::PreferredCurrency::Iota => Some(sdk::types::currencies::Currency::Iota),
-            ffi::PreferredCurrency::Smr => Some(sdk::types::currencies::Currency::Smr),
             ffi::PreferredCurrency::Eth => Some(sdk::types::currencies::Currency::Eth),
         }
     }
@@ -289,7 +288,6 @@ impl From<Option<sdk::types::currencies::Currency>> for ffi::PreferredCurrency {
         match value {
             None => Self::None,
             Some(sdk::types::currencies::Currency::Iota) => Self::Iota,
-            Some(sdk::types::currencies::Currency::Smr) => Self::Smr,
             Some(sdk::types::currencies::Currency::Eth) => Self::Eth,
         }
     }

--- a/sdk/bindings/wasm/examples/utils.ts
+++ b/sdk/bindings/wasm/examples/utils.ts
@@ -34,7 +34,7 @@ export async function initSdk(username: string) {
     }
     `);
 
-    await sdk.setCurrency(wasm.Currency.Smr);
+    await sdk.setCurrency(wasm.Currency.Iota);
 
     // Generate access token
     let access_token = await generateAccessToken(username);

--- a/sdk/bindings/wasm/examples/webapp/examples/util.js
+++ b/sdk/bindings/wasm/examples/webapp/examples/util.js
@@ -17,11 +17,11 @@ export async function initSdk() {
         "log_level": "info",
         "auth_provider": "standalone",
         "node_urls": {
-            "smr": ["https://api.testnet.shimmer.network"]
+            "iota": ["https://api.testnet.iotaledger.net"]
         }
     }
     `);
-    await sdk.setCurrency(wasm.Currency.Smr);
+    await sdk.setCurrency(wasm.Currency.Iota);
     await sdk.refreshAccessToken(process.env.ACCESS_TOKEN);
     return sdk; // Return the initialized SDK instance
 }

--- a/sdk/bindings/wasm/src/lib.rs
+++ b/sdk/bindings/wasm/src/lib.rs
@@ -55,7 +55,6 @@ impl CryptpaySdk {
     ///     "storage_path": "/path/to/valid/folder",
     ///     "log_level": "info",
     ///     "node_urls": {
-    ///         "smr": ["https://api.testnet.shimmer.network"],
     ///         "iota": ["<first node url>", "<second node url>"]
     ///     }
     /// }
@@ -74,7 +73,7 @@ impl CryptpaySdk {
 
     /// Selects the currency for the Cryptpay SDK.
     ///
-    /// @param {Currency} currency - The currency. Currently supports only SMR and IOTA.
+    /// @param {Currency} currency - The currency. Currently supports only ETH and IOTA.
     /// @returns {Promise<void>}
     #[wasm_bindgen(skip_jsdoc, js_name = "setCurrency")]
     pub async fn set_currency(&self, currency: Currency) {

--- a/sdk/bindings/wasm/src/types.rs
+++ b/sdk/bindings/wasm/src/types.rs
@@ -15,11 +15,10 @@ convert_enum!(log::Level, Level, Error, Warn, Info, Debug, Trace,);
 #[wasm_bindgen]
 pub enum Currency {
     Iota,
-    Smr,
     Eth,
 }
 
-convert_enum!(sdk::types::currencies::Currency, Currency, Iota, Smr, Eth,);
+convert_enum!(sdk::types::currencies::Currency, Currency, Iota, Eth,);
 
 #[wasm_bindgen(getter_with_clone, inspectable)]
 pub struct NewCaseIdResponse {

--- a/sdk/docs/SDK Configuration/Configuration.md
+++ b/sdk/docs/SDK Configuration/Configuration.md
@@ -468,7 +468,7 @@ The development environment is used only internally by the Cawaena development t
 
         sdk.set_path_prefix(path);
         sdk.set_env(Environment::Development);
-        sdk.set_currency(Currency::Smr);
+        sdk.set_currency(Currency::Iota);
         sdk.validate_config().unwrap();
 
         // other SDK functions
@@ -685,7 +685,7 @@ The following code snippet shows a complete example for correctly configuring th
 
         // Set environment and currency
         sdk.set_env(Environment::Development);
-        sdk.set_currency(Currency::Smr);
+        sdk.set_currency(Currency::Iota);
 
         // Set log level and initialize logger
         sdk.set_log_level("info");

--- a/sdk/examples/utils.rs
+++ b/sdk/examples/utils.rs
@@ -30,7 +30,6 @@ pub async fn init_sdk() -> (Sdk, CleanUp) {
         auth_provider: "standalone".to_string(),
         log_level: log::LevelFilter::Debug,
         node_urls: HashMap::from([
-            (Currency::Smr, vec!["https://api.testnet.shimmer.network".to_string()]),
             (Currency::Iota, vec!["https://api.testnet.iotaledger.net".to_string()]),
             (
                 Currency::Eth,
@@ -47,7 +46,7 @@ pub async fn init_sdk() -> (Sdk, CleanUp) {
     let access_token = AccessToken::try_from(access_token).unwrap();
     sdk.refresh_access_token(Some(access_token)).await.unwrap();
 
-    sdk.set_currency(Currency::Smr);
+    sdk.set_currency(Currency::Iota);
 
     (sdk, cleanup)
 }

--- a/sdk/src/backend/dlt.rs
+++ b/sdk/src/backend/dlt.rs
@@ -168,7 +168,7 @@ mod tests {
             .match_header(HEADER_X_APP_USERNAME, USERNAME)
             .match_header("authorization", format!("Bearer {}", TOKEN.as_str()).as_str())
             .match_header("content-type", "application/json")
-            .match_query(Matcher::Exact("currency=Smr".to_string()))
+            .match_query(Matcher::Exact("currency=Iota".to_string()))
             .match_body(Matcher::Exact(body))
             .with_status(status_code)
             .expect(1)
@@ -176,7 +176,7 @@ mod tests {
             .create();
 
         // Act
-        let response = put_user_address(&config, USERNAME, &TOKEN, Currency::Smr, ADDRESS).await;
+        let response = put_user_address(&config, USERNAME, &TOKEN, Currency::Iota, ADDRESS).await;
 
         // Assert
         match expected {

--- a/sdk/src/backend/transactions.rs
+++ b/sdk/src/backend/transactions.rs
@@ -325,7 +325,7 @@ mod tests {
 
         let mock_request = CreateTransactionRequest {
             amount: AMOUNT.inner(),
-            currency: ApiCryptoCurrency::Smr,
+            currency: ApiCryptoCurrency::Iota,
             receiver: RECEIVER.into(),
             application_metadata: example_tx_metadata(),
         };
@@ -354,7 +354,7 @@ mod tests {
             &TOKEN,
             USERNAME,
             RECEIVER,
-            Currency::Smr,
+            Currency::Iota,
             AMOUNT,
             example_tx_metadata(),
         )

--- a/sdk/src/backend/user.rs
+++ b/sdk/src/backend/user.rs
@@ -221,7 +221,7 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case(200, Ok(Some(Currency::Smr)))]
+    #[case(200, Ok(Some(Currency::Iota)))]
     #[case(401, Err(ApiError::MissingAccessToken))]
     #[case(500, Err(ApiError::UnexpectedResponse {
         code: StatusCode::INTERNAL_SERVER_ERROR,
@@ -245,7 +245,7 @@ mod tests {
             .with_header("content-type", "application/json");
         // Conditionally add the response body only for the 200 status code
         if status_code == 200 {
-            mock_server = mock_server.with_body("{\"currency\":\"Smr\"}");
+            mock_server = mock_server.with_body("{\"currency\":\"Iota\"}");
         }
         let mock_server = mock_server.expect(1).create();
 
@@ -290,7 +290,7 @@ mod tests {
             .create();
 
         // Act
-        let response = set_preferred_currency(&config, &TOKEN, USERNAME, Some(Currency::Smr)).await;
+        let response = set_preferred_currency(&config, &TOKEN, USERNAME, Some(Currency::Iota)).await;
 
         // Assert
         match expected {

--- a/sdk/src/backend/viviswap.rs
+++ b/sdk/src/backend/viviswap.rs
@@ -1309,7 +1309,7 @@ mod tests {
             .match_header(HEADER_X_APP_NAME, AUTH_PROVIDER)
             .match_header(HEADER_X_APP_USERNAME, USERNAME)
             .match_header("authorization", format!("Bearer {}", TOKEN.as_str()).as_str())
-            .match_query(Matcher::Exact("currency=Smr".to_string()))
+            .match_query(Matcher::Exact("currency=Iota".to_string()))
             .with_status(status_code);
         // Conditionally add the response body only for the 200 status code
         if status_code == 200 {
@@ -1318,7 +1318,7 @@ mod tests {
         let mock_server = mock_server.expect(1).create();
 
         // Act
-        let response = get_viviswap_exchange_rate(&config, &TOKEN, USERNAME, Currency::Smr).await;
+        let response = get_viviswap_exchange_rate(&config, &TOKEN, USERNAME, Currency::Iota).await;
 
         // Assert
         match expected {

--- a/sdk/src/core/config.rs
+++ b/sdk/src/core/config.rs
@@ -107,12 +107,11 @@ impl TryFrom<DeserializedConfig> for Config {
             for (k, v) in urls {
                 // parse the key into our currency
                 let currency = match k.to_lowercase().as_str() {
-                    "smr" => Currency::Smr,
                     "iota" => Currency::Iota,
                     "eth" => Currency::Eth,
                     other => {
                         return Err(crate::Error::SetConfig(format!(
-                            "invalid currency key `{other}` while parsing node_urls. Valid keys are: smr, iota, eth."
+                            "invalid currency key `{other}` while parsing node_urls. Valid keys are: iota, eth."
                         )));
                     }
                 };
@@ -214,7 +213,6 @@ impl Sdk {
 impl Config {
     fn default_test_node_urls() -> HashMap<Currency, Vec<String>> {
         HashMap::from([
-            (Currency::Smr, vec!["https://api.shimmer.network".to_string()]), // not test network
             (Currency::Iota, vec!["https://api.testnet.iotaledger.net".to_string()]),
             (
                 Currency::Eth,
@@ -326,7 +324,7 @@ mod tests {
     fn test_set_config_invalid_node_url() {
         let config = Config::try_from(valid_deserialized_config(Some(example_node_urls(Some("BTC")))));
         let error_msg =
-            "Error while setting the configuration: invalid currency key `btc` while parsing node_urls. Valid keys are: smr, iota, eth.".to_string();
+            "Error while setting the configuration: invalid currency key `btc` while parsing node_urls. Valid keys are: iota, eth.".to_string();
         assert_eq!(config.unwrap_err().to_string(), error_msg);
     }
 
@@ -398,7 +396,6 @@ mod tests {
             "auth_provider": "standalone",
             "node_urls": {
                 "IOTA": ["https://api.stardust-mainnet.iotaledger.net/"],
-                "SMR": ["https://api.testnet.shimmer.network/"],
                 "ETH": ["https://ethereum-sepolia-rpc.publicnode.com/", "31337"]
             }
           }"#,

--- a/sdk/src/core/config.rs
+++ b/sdk/src/core/config.rs
@@ -214,7 +214,7 @@ impl Sdk {
 impl Config {
     fn default_test_node_urls() -> HashMap<Currency, Vec<String>> {
         HashMap::from([
-            (Currency::Smr, vec!["https://api.testnet.shimmer.network".to_string()]),
+            (Currency::Smr, vec!["https://api.shimmer.network".to_string()]), // not test network
             (Currency::Iota, vec!["https://api.testnet.iotaledger.net".to_string()]),
             (
                 Currency::Eth,

--- a/sdk/src/core/core_testing_utils.rs
+++ b/sdk/src/core/core_testing_utils.rs
@@ -36,7 +36,7 @@ pub async fn handle_error_test_cases(
                 username: USERNAME.into(),
                 wallet_manager: Box::new(MockWalletManager::new()),
             });
-            sdk.set_currency(crate::types::currencies::Currency::Smr);
+            sdk.set_currency(crate::types::currencies::Currency::Iota);
             sdk.access_token = Some(TOKEN.clone());
             sdk.config = None;
         }

--- a/sdk/src/core/exchange.rs
+++ b/sdk/src/core/exchange.rs
@@ -65,7 +65,7 @@ mod tests {
                     wallet_manager: Box::new(MockWalletManager::new()),
                 });
                 sdk.access_token = Some(TOKEN.clone());
-                sdk.set_currency(crate::types::currencies::Currency::Smr);
+                sdk.set_currency(crate::types::currencies::Currency::Iota);
 
                 let body = serde_json::to_string(&example_exchange_rate_response()).unwrap();
                 mock_server = Some(
@@ -73,7 +73,7 @@ mod tests {
                         .match_header(HEADER_X_APP_NAME, AUTH_PROVIDER)
                         .match_header(HEADER_X_APP_USERNAME, USERNAME)
                         .match_header("authorization", format!("Bearer {}", TOKEN.as_str()).as_str())
-                        .match_query(Matcher::Exact("currency=Smr".to_string()))
+                        .match_query(Matcher::Exact("currency=Iota".to_string()))
                         .with_status(200)
                         .with_body(&body)
                         .expect(1)

--- a/sdk/src/core/mod.rs
+++ b/sdk/src/core/mod.rs
@@ -156,7 +156,7 @@ mod tests {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
                 });
-                sdk.set_currency(crate::types::currencies::Currency::Smr);
+                sdk.set_currency(crate::types::currencies::Currency::Iota);
             }
             Err(error) => {
                 handle_error_test_cases(error, &mut sdk, 0, 0).await;

--- a/sdk/src/core/transaction.rs
+++ b/sdk/src/core/transaction.rs
@@ -186,7 +186,7 @@ impl Sdk {
 
         let amount = tx_details.amount.try_into()?;
         let tx_id = match tx_details.currency {
-            api_types::api::generic::ApiCryptoCurrency::Iota | api_types::api::generic::ApiCryptoCurrency::Smr => {
+            api_types::api::generic::ApiCryptoCurrency::Iota => {
                 wallet
                     .send_transaction(purchase_id, &tx_details.system_address, amount)
                     .await?
@@ -265,7 +265,7 @@ impl Sdk {
         let tagged_data_payload = Some(TaggedDataPayload::new(tag, data).map_err(WalletError::Block)?);
 
         match currency {
-            Currency::Iota | Currency::Smr => wallet
+            Currency::Iota => wallet
                 .send_amount(address, amount, tagged_data_payload, message)
                 .await?
                 .transaction_id
@@ -520,7 +520,7 @@ mod tests {
                     block_id: Some("0x215322f8afdba4e22463a9d8a2e25d96ab0cb9ae6d56ee5ab13065068dae46c0".to_string()),
                     username: "satoshi".into(),
                     address: main_address.clone(),
-                    currency: "SMR".to_string(),
+                    currency: "IOTA".to_string(),
                     amount: dec!(920.89),
                     exchange_rate: dec!(0.06015),
                 },
@@ -531,7 +531,7 @@ mod tests {
                     block_id: Some("0x215322f8afdba4e22463a9d8a2e25d96ab0cb9ae6d56ee5ab13065068dae46c0".to_string()),
                     username: "hulk".into(),
                     address: aux_address.clone(),
-                    currency: "SMR".to_string(),
+                    currency: "IOTA".to_string(),
                     amount: dec!(920.89),
                     exchange_rate: dec!(0.06015),
                 },
@@ -550,7 +550,7 @@ mod tests {
         // Arrange
         let (mut srv, config, _cleanup) = set_config().await;
         let mut sdk = Sdk::new(config).unwrap();
-        sdk.set_currency(Currency::Smr);
+        sdk.set_currency(Currency::Iota);
         let mut mock_server = None;
 
         match &expected {

--- a/sdk/src/core/user.rs
+++ b/sdk/src/core/user.rs
@@ -582,7 +582,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case::success(Ok(Some(Currency::Smr)))]
+    #[case::success(Ok(Some(Currency::Iota)))]
     #[case::user_init_error(Err(crate::Error::UserNotInitialized))]
     #[case::unauthorized(Err(crate::Error::MissingAccessToken))]
     #[case::missing_config(Err(crate::Error::MissingConfig))]
@@ -608,7 +608,7 @@ mod tests {
                         .match_header("authorization", format!("Bearer {}", TOKEN.as_str()).as_str())
                         .with_status(200)
                         .with_header("content-type", "application/json")
-                        .with_body("{\"currency\":\"Smr\"}")
+                        .with_body("{\"currency\":\"Iota\"}")
                         .expect(1)
                         .create(),
                 );

--- a/sdk/src/core/viviswap/swap.rs
+++ b/sdk/src/core/viviswap/swap.rs
@@ -786,11 +786,6 @@ mod tests {
         SwapPaymentDetailKey::Eth,
         "/api/viviswap/details?payment_method_key=ETH"
     )]
-    #[case(
-        Currency::Smr,
-        SwapPaymentDetailKey::Smr,
-        "/api/viviswap/details?payment_method_key=SMR"
-    )]
     #[tokio::test]
     async fn it_should_create_viviswap_deposit(
         #[case] currency: Currency,                       // Parametrized currency

--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -518,9 +518,7 @@ impl Sdk {
         let wallet = self.try_get_active_user_wallet(pin).await?;
 
         let tx_list = match currency {
-            crate::types::currencies::Currency::Iota | crate::types::currencies::Currency::Smr => {
-                wallet.get_wallet_tx_list(start, limit).await?
-            }
+            crate::types::currencies::Currency::Iota => wallet.get_wallet_tx_list(start, limit).await?,
             crate::types::currencies::Currency::Eth => {
                 // We retrieve the transaction list from the wallet,
                 // then synchronize selected transactions (by fetching their current status from the network),
@@ -1020,7 +1018,7 @@ mod tests {
                     wallet_manager: Box::new(mock_wallet_manager),
                 });
                 sdk.access_token = Some(TOKEN.clone());
-                sdk.set_currency(crate::types::currencies::Currency::Smr);
+                sdk.set_currency(crate::types::currencies::Currency::Iota);
 
                 let mock_request = SetUserAddressRequest {
                     address: ADDRESS.into(),
@@ -1033,7 +1031,7 @@ mod tests {
                         .match_header(HEADER_X_APP_USERNAME, USERNAME)
                         .match_header("authorization", format!("Bearer {}", TOKEN.as_str()).as_str())
                         .match_header("content-type", "application/json")
-                        .match_query(Matcher::Exact("currency=Smr".to_string()))
+                        .match_query(Matcher::Exact("currency=Iota".to_string()))
                         .match_body(Matcher::Exact(body))
                         .with_status(201)
                         .expect(1)
@@ -1094,7 +1092,7 @@ mod tests {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
                 });
-                sdk.set_currency(crate::types::currencies::Currency::Smr);
+                sdk.set_currency(crate::types::currencies::Currency::Iota);
             }
             Err(error) => {
                 handle_error_test_cases(error, &mut sdk, 1, 0).await;
@@ -1144,7 +1142,7 @@ mod tests {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
                 });
-                sdk.set_currency(crate::types::currencies::Currency::Smr);
+                sdk.set_currency(crate::types::currencies::Currency::Iota);
             }
             Err(error) => {
                 handle_error_test_cases(error, &mut sdk, 1, 0).await;
@@ -1195,7 +1193,7 @@ mod tests {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
                 });
-                sdk.set_currency(crate::types::currencies::Currency::Smr);
+                sdk.set_currency(crate::types::currencies::Currency::Iota);
             }
             Err(error) => {
                 handle_error_test_cases(error, &mut sdk, 2, 0).await;
@@ -1242,7 +1240,7 @@ mod tests {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
                 });
-                sdk.set_currency(crate::types::currencies::Currency::Smr);
+                sdk.set_currency(crate::types::currencies::Currency::Iota);
             }
             Err(error) => {
                 handle_error_test_cases(error, &mut sdk, 1, 0).await;

--- a/sdk/src/testing_utils.rs
+++ b/sdk/src/testing_utils.rs
@@ -75,6 +75,9 @@ pub const SALT: [u8; 12] = [241, 167, 131, 245, 166, 203, 63, 247, 211, 157, 138
 pub const PURCHASE_ID: &str = "123";
 pub const ORDER_ID: &str = "497f6eca-6276-4993-bfeb-53cbbbba6f08";
 pub static PIN: LazyLock<EncryptionPin> = LazyLock::new(|| EncryptionPin::try_from_string("1234").unwrap());
+
+/// Mnemonic for testing.
+/// Iota: tst1qz7m7xtfppy9xd73xvsnpvlnx5rcewjz2k2gqh6w67tdleks83rh768k6rc
 pub const MNEMONIC:&str = "aware mirror sadness razor hurdle bus scout crisp close life science spy shell fine loop govern country strategy city soldier select diet brain return";
 
 // util function to set the config

--- a/sdk/src/testing_utils.rs
+++ b/sdk/src/testing_utils.rs
@@ -58,8 +58,8 @@ pub const RECEIVER: &str = "satoshi";
 pub const APP_DATA: &str = "app_data";
 pub const START: u32 = 1;
 pub const LIMIT: u32 = 10;
-pub const PAYMENT_METHOD_KEY: SwapPaymentDetailKey = SwapPaymentDetailKey::Smr;
-pub const PAYMENT_METHOD_KEY_SERIALIZED: &str = "SMR";
+pub const PAYMENT_METHOD_KEY: SwapPaymentDetailKey = SwapPaymentDetailKey::Iota;
+pub const PAYMENT_METHOD_KEY_SERIALIZED: &str = "IOTA";
 pub const PAYMENT_METHOD_ID: &str = "payment-method-id";
 pub const PAYMENT_DETAIL_ID: &str = "payment-detail-id";
 pub const CASE_ID: &str = "123";
@@ -118,7 +118,7 @@ pub fn example_get_user(key: SwapPaymentDetailKey, verified: bool, times: usize,
                             key: SwapPaymentDetailKey::Sepa,
                             min_amount: 1.5f32,
                             max_amount: 1000.4422f32,
-                            supported_deposit_currencies: Vec::from(["SMR".into(), "IOTA".into()]),
+                            supported_deposit_currencies: Vec::from(["IOTA".into()]),
                             supported_withdrawal_method_keys: Vec::from([SwapPaymentDetailKey::Sepa]),
                             contract_type: "Standard".into(),
                             is_incoming_payment_detail_required: true,
@@ -130,7 +130,7 @@ pub fn example_get_user(key: SwapPaymentDetailKey, verified: bool, times: usize,
                             key,
                             min_amount: 1.5f32,
                             max_amount: 1000.4422f32,
-                            supported_deposit_currencies: Vec::from(["SMR".into(), "IOTA".into()]),
+                            supported_deposit_currencies: Vec::from(["IOTA".into()]),
                             supported_withdrawal_method_keys: Vec::from([key]),
                             contract_type: "Standard".into(),
                             is_incoming_payment_detail_required: true,
@@ -191,7 +191,7 @@ pub fn example_viviswap_oder_response() -> Order {
         crypto_fees: 0.0f32,
         contract_id: "contract-id".into(),
         incoming_payment_method_id: PAYMENT_METHOD_ID.into(),
-        incoming_payment_method_currency: "SMR".to_string(),
+        incoming_payment_method_currency: "IOTA".to_string(),
         incoming_amount: 1.0f32,
         incoming_course: 1.0f32,
         outgoing_payment_method_id: PAYMENT_METHOD_ID.into(),
@@ -275,10 +275,6 @@ pub fn example_customer() -> Customer {
 
 pub fn example_node_urls(invalid_currency: Option<&str>) -> HashMap<String, Vec<String>> {
     let mut node_urls = HashMap::from([
-        (
-            "SMR".to_string(),
-            vec!["https://api.testnet.shimmer.network/".to_string()],
-        ),
         (
             "IOTA".to_string(),
             vec!["https://api.stardust-mainnet.iotaledger.net/".to_string()],

--- a/sdk/src/types/currencies.rs
+++ b/sdk/src/types/currencies.rs
@@ -1,6 +1,6 @@
 use super::error::{Result, TypeError};
 use api_types::api::{generic::ApiCryptoCurrency, viviswap::detail::SwapPaymentDetailKey};
-use iota_sdk::client::constants::{ETHER_COIN_TYPE, IOTA_COIN_TYPE, SHIMMER_COIN_TYPE};
+use iota_sdk::client::constants::{ETHER_COIN_TYPE, IOTA_COIN_TYPE};
 use serde::Serialize;
 
 /// Supported currencies (mirrors `api_types` but needed so we can implement the additional
@@ -9,8 +9,6 @@ use serde::Serialize;
 pub enum Currency {
     /// Iota token
     Iota,
-    /// Shimmer token
-    Smr,
     /// Ethereum token
     Eth,
 }
@@ -21,7 +19,6 @@ impl TryFrom<String> for Currency {
     fn try_from(currency: String) -> Result<Self> {
         match currency.to_lowercase().as_str() {
             "iota" => Ok(Self::Iota),
-            "smr" => Ok(Self::Smr),
             "eth" => Ok(Self::Eth),
             _ => Err(TypeError::InvalidCurrency(currency)),
         }
@@ -35,7 +32,6 @@ impl Currency {
     pub fn coin_type(self) -> u32 {
         match self {
             Self::Iota => IOTA_COIN_TYPE,
-            Self::Smr => SHIMMER_COIN_TYPE,
             Self::Eth => ETHER_COIN_TYPE,
         }
     }
@@ -44,7 +40,6 @@ impl Currency {
     pub fn to_vivi_payment_method_key(self) -> SwapPaymentDetailKey {
         match self {
             Self::Iota => SwapPaymentDetailKey::Iota,
-            Self::Smr => SwapPaymentDetailKey::Smr,
             Self::Eth => SwapPaymentDetailKey::Eth,
         }
     }
@@ -55,7 +50,6 @@ impl From<Currency> for ApiCryptoCurrency {
     fn from(value: Currency) -> Self {
         match value {
             Currency::Iota => ApiCryptoCurrency::Iota,
-            Currency::Smr => ApiCryptoCurrency::Smr,
             Currency::Eth => ApiCryptoCurrency::Eth,
         }
     }
@@ -64,7 +58,6 @@ impl From<ApiCryptoCurrency> for Currency {
     fn from(value: ApiCryptoCurrency) -> Self {
         match value {
             ApiCryptoCurrency::Iota => Currency::Iota,
-            ApiCryptoCurrency::Smr => Currency::Smr,
             ApiCryptoCurrency::Eth => Currency::Eth,
         }
     }
@@ -76,7 +69,6 @@ impl std::fmt::Display for Currency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Currency::Iota => write!(f, "Iota"),
-            Currency::Smr => write!(f, "Smr"),
             Currency::Eth => write!(f, "Eth"),
         }
     }
@@ -172,7 +164,7 @@ mod test {
     use super::CryptoAmount;
 
     #[rstest::rstest]
-    fn test_display_roundtrip(#[values(Currency::Smr, Currency::Iota, Currency::Eth)] c: Currency) {
+    fn test_display_roundtrip(#[values(Currency::Iota, Currency::Eth)] c: Currency) {
         assert_eq!(c, Currency::try_from(c.to_string()).unwrap());
     }
 

--- a/sdk/src/types/transactions.rs
+++ b/sdk/src/types/transactions.rs
@@ -58,7 +58,6 @@ pub struct WalletTxInfo {
     /// Url of network SMR/IOTA/ETH
     pub explorer_url: Option<String>, // ok
                                       // change based on the network either shimmer or iota
-                                      // base explorer url for SMR = https://explorer.shimmer.network/shimmer/block/[block_id]
                                       // base explorer url for IOTA = https://explorer.iota.org/mainnet/block/[block_id]
                                       // base explorer url for EVM = [node url]
 }
@@ -90,13 +89,6 @@ impl From<Transaction> for WalletTxInfo {
                     .block_id
                     .map(|id| format!("https://explorer.iota.org/mainnet/block/{id}"));
                 ("IOTA", explorer_url)
-            }
-
-            id if id == network_name_to_id("shimmer") => {
-                let explorer_url = transaction
-                    .block_id
-                    .map(|id| format!("https://explorer.shimmer.network/shimmer/block/{id}"));
-                ("SMR", explorer_url)
             }
             id => {
                 log::error!("unknown network id: {id}");

--- a/sdk/src/wallet/wallet_manager.rs
+++ b/sdk/src/wallet/wallet_manager.rs
@@ -557,7 +557,7 @@ impl WalletManager for WalletManagerImpl {
         }
 
         let bo = match currency {
-            Currency::Iota | Currency::Smr => {
+            Currency::Iota => {
                 let wallet = WalletImplStardust::new(config, mnemonic, &path, currency).await?;
                 Box::new(wallet) as Box<dyn WalletUser + Sync + Send>
             }
@@ -707,7 +707,7 @@ mod tests {
             .expect("should succeed to change wallet password");
 
         let wallet = manager
-            .try_get(&mut config, &None, &mut repo, Currency::Smr, &pin)
+            .try_get(&mut config, &None, &mut repo, Currency::Iota, &pin)
             .await
             .expect("should succeed to get wallet after password change");
 
@@ -729,7 +729,7 @@ mod tests {
 
         // get the wallet instance to make sure any files are created
         let _wallet = manager
-            .try_get(&mut config, &None, &mut repo, Currency::Smr, &pin)
+            .try_get(&mut config, &None, &mut repo, Currency::Iota, &pin)
             .await
             .expect("should succeed to get wallet");
 
@@ -949,7 +949,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
             let wallet = manager
-                .try_get(&mut config, &access_token, &mut repo, Currency::Smr, &pin)
+                .try_get(&mut config, &access_token, &mut repo, Currency::Iota, &pin)
                 .await
                 .unwrap();
 

--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -514,6 +514,8 @@ mod tests {
 
         let address = wallet_user.get_address().await.unwrap(); // tst1qzlzd9q4aygcnuteefaekd2kvatpt3xp673sspr2hcw27zuewxpmugyavz9
         let index = String::from("TestMessageFromStandalone");
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
         let amount = CryptoAmount::try_from(dec!(10.0)).unwrap();
         // Act
         let transaction = prepare_and_send_transaction(&wallet_user, &index, &address, amount).await;
@@ -573,9 +575,10 @@ mod tests {
         let mnemonic = "champion legend palm hollow describe timber coast lonely future holiday head torch race orange ranch gun broccoli average margin glue age awake nurse erase";
         let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
         let address = wallet_user.get_address().await.unwrap();
-        println!("address: {address}");
         let index = String::from("TestMessageFromStandalone");
-        let amount = wallet_user.get_balance().await.unwrap() + CryptoAmount::try_from(dec!(10.0)).unwrap();
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
+        let amount = balance + CryptoAmount::try_from(dec!(10.0)).unwrap();
 
         // Act
         let transaction = wallet_user.send_transaction(&index, &address, amount).await;
@@ -592,9 +595,10 @@ mod tests {
         let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap(); // st1qz46hgjrtjkgxvmqn6q42l832w3mjerdjxfv756hc4fnrlfeh9g07ge7m2w
-        println!("address: {address}");
         let index = String::from("TestMessageFromStandalone");
-        let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
+        let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
 
         // Act
         let transaction = wallet_user.send_transaction(&index, &address, amount).await;
@@ -612,10 +616,11 @@ mod tests {
 
         let address = wallet_user.get_address().await.unwrap(); // tst1qpaha27ytq8ay3ahqlfl6rn5xndnwxwahunf20h59cadpt9q2gx0crqekxk
 
-        // println!("address: {address}");
-        let index = String::from("TestMessageFromStandalone");
-        let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
+        let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
 
+        let index = String::from("TestMessageFromStandalone");
         let transaction = prepare_and_send_transaction(&wallet_user, &index, &address, amount)
             .await
             .unwrap();
@@ -642,11 +647,11 @@ mod tests {
         let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap(); //tst1qq68c239vacsq3gnksqss5glh9e3w0wc9mra9d6cs39e8hs3xrmgjscdpac
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
+        let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
 
-        // println!("address: {address}");
         let index = String::from("TestMessageFromStandalone");
-        let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
-
         let transaction = prepare_and_send_transaction(&wallet_user, &index, &address, amount)
             .await
             .unwrap();
@@ -681,7 +686,10 @@ mod tests {
         let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap();
-        let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
+
+        let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
         let tag: Box<[u8]> = "test tag".to_string().into_bytes().into_boxed_slice();
         let data: Box<[u8]> = (amount.inner() * dec!(1_000_000))
             .round()
@@ -717,7 +725,9 @@ mod tests {
         let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap();
-        let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
+        let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
 
         // Act
         let result = wallet_user.send_amount(&address, amount, None, None).await;
@@ -735,6 +745,8 @@ mod tests {
         let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap();
+        let balance = wallet_user.get_balance().await.unwrap();
+        println!("Address: {address}, balance: {balance:?}");
         let amount = CryptoAmount::try_from(dec!(96854.0)).unwrap();
 
         // Act

--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -539,7 +539,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Currency::Smr, "smr")]
     #[case(Currency::Iota, "tst")]
     #[tokio::test]
     async fn test_get_address(#[case] currency: Currency, #[case] expected_prefix: &str) {
@@ -558,7 +557,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Currency::Smr)]
     #[case(Currency::Iota)]
     #[tokio::test]
     async fn test_get_balance(#[case] currency: Currency) {
@@ -671,7 +669,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_wallet_tx_error_nonexistent_transaction() {
         // Arrange
-        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
         let transaction_id = "nonexistent_transaction_id";
 

--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -510,9 +510,9 @@ mod tests {
         // Arrange
         let mnemonic = "predict wrist plug desert mobile crowd build leg swap impose breeze loyal surge brand hair bronze melody scale hello cereal car item slow bring";
 
-        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
 
-        let address = wallet_user.get_address().await.unwrap();
+        let address = wallet_user.get_address().await.unwrap(); // tst1qzlzd9q4aygcnuteefaekd2kvatpt3xp673sspr2hcw27zuewxpmugyavz9
         let index = String::from("TestMessageFromStandalone");
         let amount = CryptoAmount::try_from(dec!(10.0)).unwrap();
         // Act
@@ -534,7 +534,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Currency::Smr, "rms")]
+    #[case(Currency::Smr, "smr")]
     #[case(Currency::Iota, "tst")]
     #[tokio::test]
     async fn test_get_address(#[case] currency: Currency, #[case] expected_prefix: &str) {
@@ -571,8 +571,9 @@ mod tests {
     async fn test_send_tx_more_than_balance() {
         // Arrange
         let mnemonic = "champion legend palm hollow describe timber coast lonely future holiday head torch race orange ranch gun broccoli average margin glue age awake nurse erase";
-        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
         let address = wallet_user.get_address().await.unwrap();
+        println!("address: {address}");
         let index = String::from("TestMessageFromStandalone");
         let amount = wallet_user.get_balance().await.unwrap() + CryptoAmount::try_from(dec!(10.0)).unwrap();
 
@@ -588,9 +589,10 @@ mod tests {
     async fn test_send_tx_less_than_balance() {
         // Arrange
         let mnemonic = "arch sentence dwarf label unlock grace left orient practice oval sport rubber airport carbon moral can scan clinic false hen fancy repeat hip green";
-        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
 
-        let address = wallet_user.get_address().await.unwrap();
+        let address = wallet_user.get_address().await.unwrap(); // st1qz46hgjrtjkgxvmqn6q42l832w3mjerdjxfv756hc4fnrlfeh9g07ge7m2w
+        println!("address: {address}");
         let index = String::from("TestMessageFromStandalone");
         let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
 
@@ -606,9 +608,11 @@ mod tests {
     async fn test_serial_get_wallet_tx_list() {
         // Arrange
         let mnemonic = "west neutral cannon wreck notice disorder message three phrase accident office flavor merit kiss claim finish finger forum mesh mouse torch cradle inside glue";
-        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
 
-        let address = wallet_user.get_address().await.unwrap();
+        let address = wallet_user.get_address().await.unwrap(); // tst1qpaha27ytq8ay3ahqlfl6rn5xndnwxwahunf20h59cadpt9q2gx0crqekxk
+
+        // println!("address: {address}");
         let index = String::from("TestMessageFromStandalone");
         let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
 
@@ -635,9 +639,11 @@ mod tests {
     async fn test_serial_get_wallet_tx_success() {
         // Arrange
         let mnemonic = "century jazz giant zebra pledge head school supreme aim certain moment mechanic curtain chronic duck addict despair pistol romance risk impulse upgrade rubber grid";
-        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(mnemonic, Currency::Iota).await;
 
-        let address = wallet_user.get_address().await.unwrap();
+        let address = wallet_user.get_address().await.unwrap(); //tst1qq68c239vacsq3gnksqss5glh9e3w0wc9mra9d6cs39e8hs3xrmgjscdpac
+
+        // println!("address: {address}");
         let index = String::from("TestMessageFromStandalone");
         let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
 
@@ -672,7 +678,7 @@ mod tests {
     #[tokio::test]
     async fn it_should_send_amount_with_tag_and_message() {
         // Arrange
-        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap();
         let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
@@ -708,7 +714,7 @@ mod tests {
     #[tokio::test]
     async fn it_should_send_amount_without_tag_and_message() {
         // Arrange
-        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap();
         let amount = CryptoAmount::try_from(wallet_user.get_balance().await.unwrap().inner() - dec!(1.0)).unwrap();
@@ -726,7 +732,7 @@ mod tests {
     #[tokio::test]
     async fn it_should_not_send_amount_more_then_balance() {
         // Arrange
-        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Smr).await;
+        let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
         let address = wallet_user.get_address().await.unwrap();
         let amount = CryptoAmount::try_from(dec!(96854.0)).unwrap();
@@ -735,11 +741,14 @@ mod tests {
         let transaction = wallet_user.send_amount(&address, amount, None, None).await;
 
         // Assert
-        assert!(matches!(
-            transaction,
-            Err(WalletError::IotaWallet(
-                iota_sdk::wallet::Error::InsufficientFunds { .. }
-            ))
-        ));
+        assert!(
+            matches!(
+                transaction,
+                Err(WalletError::IotaWallet(
+                    iota_sdk::wallet::Error::InsufficientFunds { .. }
+                ))
+            ),
+            "Got: {transaction:?}"
+        );
     }
 }

--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -392,7 +392,10 @@ impl WalletUser for WalletImplStardust {
     async fn sync_wallet(&self) -> Result<()> {
         let account = self.account_manager.get_account(APP_NAME).await?;
 
-        let options = SyncOptions { ..Default::default() };
+        let options = SyncOptions {
+            force_syncing: true,
+            ..Default::default()
+        };
         account.sync(Some(options)).await?;
 
         Ok(())

--- a/sdk/tests/rt_config.rs
+++ b/sdk/tests/rt_config.rs
@@ -19,7 +19,6 @@ async fn it_should_get_node_urls() {
 
     // Assert response
     let response = result.unwrap();
-    assert!(response.contains_key("SMR"));
     assert!(response.contains_key("IOTA"));
 }
 

--- a/sdk/tests/utils/mod.rs
+++ b/sdk/tests/utils/mod.rs
@@ -27,7 +27,6 @@ pub async fn init_sdk_with_cleanup(username: &str, existing_cleanup: CleanUp) ->
         auth_provider: "standalone".to_string(),
         log_level: log::LevelFilter::Debug,
         node_urls: HashMap::from([
-            (Currency::Smr, vec!["https://api.testnet.shimmer.network".to_string()]),
             (Currency::Iota, vec!["https://api.testnet.iotaledger.net".to_string()]),
             (
                 Currency::Eth,
@@ -43,7 +42,7 @@ pub async fn init_sdk_with_cleanup(username: &str, existing_cleanup: CleanUp) ->
     let access_token = AccessToken::try_from(access_token).unwrap();
     sdk.refresh_access_token(Some(access_token)).await.unwrap();
 
-    sdk.set_currency(Currency::Smr);
+    sdk.set_currency(Currency::Iota);
 
     (sdk, existing_cleanup)
 }


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

Shimmer testnet is deprecated, so we need to switch to using the IOTA testnet for unit-tests and examples.

## Summary

Provide a short summary of changes in this pull request.

- Add a ci job that runs all unit tests (coverage job excludes some wallet-related tests)
- Use Iota wallet instead of Smr for unit tests. Fix code that syncs the wallet to always sync, instead of skipping whenever two syncs happen too close in time.
- use iota for examples and regression tests
- Remove shimmer support completely

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [x] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
