### PR TITLE
chore(ci): use hosted mac runner for building swift bindings, bundle only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for clippy warnings
         run: cargo clippy --all-targets --all-features --color always -- -D warnings
@@ -98,6 +99,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -128,6 +130,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -158,6 +161,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -208,6 +212,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-ndk
         uses: taiki-e/install-action@v2
@@ -227,18 +232,30 @@ jobs:
           overwrite: true
 
   build-sdk-swift:
-    runs-on: macOS
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin,x86_64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.0.1"
+
       - name: Build swift sdk
         run: |
           cd sdk/bindings/swift
-          which cargo
-          which sccache
           make compile_swift_main
           make xcframework
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -288,6 +305,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run android bindings tests
         run: cd sdk/bindings/android/tests && gradle test
@@ -302,6 +320,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run jnigen integration test
         run: cd tools/jnigen-integration-test && gradle test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,41 +196,6 @@ jobs:
           retention-days: 7
           overwrite: true
 
-  build-sdk-android:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
-      - uses: Swatinem/rust-cache@v2
-      - uses: nttld/setup-ndk@v1
-        with:
-          ndk-version: r26d
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "21.12"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install cargo-ndk
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-ndk
-
-      - name: Build android sdk
-        run: cd sdk/bindings/android && make bundle
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: cryptpay-sdk-android
-          path: sdk/bindings/android/jar/
-          if-no-files-found: error
-          retention-days: 7
-          overwrite: true
-
   build-sdk-swift:
     runs-on: macos-latest
     steps:
@@ -254,7 +219,6 @@ jobs:
         run: |
           cd sdk/bindings/swift
           make compile_swift_main
-          make xcframework
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
@@ -264,36 +228,6 @@ jobs:
           if-no-files-found: error
           retention-days: 7
           overwrite: true
-
-  deploy-sdk-swift:
-    runs-on: macOS
-    needs: build-sdk-swift
-    steps:
-      - name: Checkout target repository
-        uses: actions/checkout@v4
-        with:
-          repository: ETOSPHERES-Labs/cawaena-sdk-swift
-          token: ${{ secrets.SWIFT_PAT_GITHUB_ACTIONS }}
-          path: target-repo
-
-      - name: Copy built artifacts to target repository
-        run: |
-          cp -R sdk/bindings/swift/CawaenaSdk/Package.swift target-repo/
-          cp -R sdk/bindings/swift/CawaenaSdk/README.md target-repo/
-          cp -R sdk/bindings/swift/CawaenaSdk/Sources target-repo/
-
-      - name: Configure Git for commit
-        run: |
-          cd target-repo
-          git config user.email "bot@cawaena.com"
-          git config user.name "bot"
-
-      - name: Commit and push changes
-        run: |
-          cd target-repo
-          git add .
-          git commit -m "Update Swift SDK package files from commit ${{ github.sha }}" || echo "No changes to commit"
-          git push
 
   android-bindings-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,117 @@
+name: Deploy
+
+# only run this on push to main (eg. after PR merge)
+on:
+  push:
+    branches:
+     - main
+
+env:
+  CARGO_TERM_COLOR: always
+  # Disable incremental compilation for faster from-scratch builds
+  CARGO_INCREMENTAL: 0
+
+# cancel the job if a newer pipeline starts for the same MR or branch
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-sdk-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
+      - uses: Swatinem/rust-cache@v2
+      - uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r26d
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cargo-ndk
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-ndk
+
+      - name: Build android sdk bundle
+        run: cd sdk/bindings/android && make bundle
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cryptpay-sdk-android
+          path: sdk/bindings/android/jar/
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
+  build-sdk-swift:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios,aarch64-apple-darwin,x86_64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "21.12"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.0.1"
+
+      - name: Build swift sdk
+        run: |
+          cd sdk/bindings/swift
+          make xcframework
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cawaena-sdk-swift
+          path: sdk/bindings/swift/CawaenaSdk
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
+
+  deploy-sdk-swift:
+    runs-on: macos-latest
+    needs: build-sdk-swift
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: ETOSPHERES-Labs/cawaena-sdk-swift
+          token: ${{ secrets.SWIFT_PAT_GITHUB_ACTIONS }}
+          path: target-repo
+
+      - name: Copy built artifacts to target repository
+        run: |
+          cp -R sdk/bindings/swift/CawaenaSdk/Package.swift target-repo/
+          cp -R sdk/bindings/swift/CawaenaSdk/README.md target-repo/
+          cp -R sdk/bindings/swift/CawaenaSdk/Sources target-repo/
+
+      - name: Configure Git for commit
+        run: |
+          cd target-repo
+          git config user.email "bot@cawaena.com"
+          git config user.name "bot"
+
+      - name: Commit and push changes
+        run: |
+          cd target-repo
+          git add .
+          git commit -m "Update Swift SDK package files from commit ${{ github.sha }}" || echo "No changes to commit"
+          git push
+

--- a/sdk/bindings/swift/Makefile
+++ b/sdk/bindings/swift/Makefile
@@ -63,7 +63,7 @@ xcframework:
 
 compile_swift_main:
 	cargo build --release
-	swiftc -L ../../../target/release \
+	xcrun swiftc -L ../../../target/release \
   		-lwalletsdk_cabi\
   		-import-objc-header ./include/bridging-header.h \
 		-framework CoreFoundation -framework SystemConfiguration \


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

This changes the job that builds the swift bindings bundle to run on the hosted macos runners. It also adds a new CI workflow that runs only on push to main (eg. when merging a PR). That way we now have:
- all pushes build wasm bindings and swift and android bindings for native platform only.
- Building the xcframework and bundling the java jar (compiled for four different targets) is now performed only on pushes to main.

Less waste and faster CI, and we still build and test all bindings on each push to a feature branch (we just do not build for all platforms all the time) 🚀 

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
