### PR TITLE
fix(ci): remove unused nextest group assignment

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -14,11 +14,7 @@ path = "junit.xml"
 [test-groups]
 serial-tests = { max-threads = 1 }
 
-# Assign the integration tests in some packages to the serial-tests group
-[[profile.default.overrides]]
-filter = 'kind(test) & binary_id(/::it_.*/)'
-test-group = 'serial-tests'
-
+# Assign the tests in some packages to the serial-tests group
 [[profile.default.overrides]]
 filter = '(package(sdk) & kind(lib) & test(/\btest_serial_/))'
 test-group = 'serial-tests'


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

Nextest released a new version that contains a "fix" that outputs an error when a filter for a test group assignment does not match anything. This PR fixes that by removing the unused filter 💯 

Release Notes: https://github.com/nextest-rs/nextest/releases/tag/cargo-nextest-0.9.92

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
