### PR TITLE
send smaller amount

### DIFF
--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -274,8 +274,8 @@ impl WalletImplStardust {
     }
 }
 
-/// The minimum amount of SMR to consider an output as non-dust output. Everything below this is dust.
-const MIN_DUST_OUTPUT: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(1.0)) }; // SAFETY: the value is non-negative
+/// The minimum amount of IOTA to consider an output as non-dust output. Everything below this is dust.
+const MIN_DUST_OUTPUT: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(0.1)) }; // SAFETY: the value is non-negative
 
 /// The value to divide an amount in GLOW with to get IOTA
 const GLOW_TO_IOTA_DIVISOR: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(1_000_000)) }; // SAFETY: the value is non-negative

--- a/sdk/tests/rt_transaction.rs
+++ b/sdk/tests/rt_transaction.rs
@@ -3,9 +3,15 @@ use crate::utils::init_sdk;
 
 use api_types::api::transactions::ApiTxStatus;
 use rust_decimal_macros::dec;
-use sdk::types::currencies::CryptoAmount;
-use std::time::Duration;
-use testing::{USER_HANS34, USER_HANS48, USER_SATOSHI};
+use sdk::{
+    core::{Config, Sdk},
+    types::{
+        currencies::{CryptoAmount, Currency},
+        newtypes::AccessToken,
+    },
+};
+use std::{collections::HashMap, path::Path, time::Duration};
+use testing::{CleanUp, USER_HANS34, USER_HANS48, USER_SATOSHI};
 use tokio::time;
 
 #[tokio::test]
@@ -82,7 +88,43 @@ async fn it_should_create_purchase_request_and_confirm_it() {
     // Arrange
     dotenvy::dotenv().ok(); // only for this test since we load the mnemonic from .env
     let user: utils::TestUser = (*USER_HANS34).clone().into();
-    let (mut sdk, _cleanup) = init_sdk(&user.username).await;
+
+    /*
+    configure sdk manually to run only this test on the iota mainnet
+    */
+    let password = std::env::var("SATOSHI_PASSWORD").unwrap();
+    let backend_url =
+        std::env::var("RT_API_URL").expect("RT_API_URL should be set with the backend url for the tests to use");
+
+    let config = Config {
+        backend_url: backend_url.parse().expect("RT_API_URL must be a valid URL"),
+        path_prefix: Path::new(&CleanUp::default().path_prefix).into(),
+        auth_provider: "standalone".to_string(),
+        log_level: log::LevelFilter::Debug,
+        node_urls: HashMap::from([
+            (
+                Currency::Iota,
+                vec!["https://api.stardust-mainnet.iotaledger.net".to_string()],
+            ),
+            (
+                Currency::Eth,
+                vec!["https://ethereum-sepolia-rpc.publicnode.com".to_string()],
+            ),
+        ]),
+    };
+
+    let mut sdk = Sdk::new(config).expect("should not fail to initialize sdk"); // set the backend url if the environment variable is set
+
+    // generate access token
+    let access_token = testing::get_access_token(&user.username, &password).await.access_token;
+    let access_token = AccessToken::try_from(access_token).unwrap();
+    sdk.refresh_access_token(Some(access_token)).await.unwrap();
+
+    sdk.set_currency(Currency::Iota);
+
+    /*
+    rest of the test
+    */
 
     sdk.create_new_user(&user.username).await.unwrap();
     sdk.init_user(&user.username).await.unwrap();

--- a/sdk/tests/rt_transaction.rs
+++ b/sdk/tests/rt_transaction.rs
@@ -92,13 +92,14 @@ async fn it_should_create_purchase_request_and_confirm_it() {
     /*
     configure sdk manually to run only this test on the iota mainnet
     */
+    let existing_cleanup = CleanUp::default();
     let password = std::env::var("SATOSHI_PASSWORD").unwrap();
     let backend_url =
         std::env::var("RT_API_URL").expect("RT_API_URL should be set with the backend url for the tests to use");
 
     let config = Config {
         backend_url: backend_url.parse().expect("RT_API_URL must be a valid URL"),
-        path_prefix: Path::new(&CleanUp::default().path_prefix).into(),
+        path_prefix: Path::new(&existing_cleanup.path_prefix).into(),
         auth_provider: "standalone".to_string(),
         log_level: log::LevelFilter::Debug,
         node_urls: HashMap::from([

--- a/sdk/tests/rt_transaction.rs
+++ b/sdk/tests/rt_transaction.rs
@@ -100,7 +100,7 @@ async fn it_should_create_purchase_request_and_confirm_it() {
     let purchase_type = "CLIK";
 
     // Act
-    let amount = CryptoAmount::try_from(dec!(2.0)).unwrap();
+    let amount = CryptoAmount::try_from(dec!(0.1)).unwrap();
     let purchase_id = sdk
         .create_purchase_request("alice", amount, product_hash, app_data, purchase_type)
         .await

--- a/sdk/tests/utils/mod.rs
+++ b/sdk/tests/utils/mod.rs
@@ -27,10 +27,7 @@ pub async fn init_sdk_with_cleanup(username: &str, existing_cleanup: CleanUp) ->
         auth_provider: "standalone".to_string(),
         log_level: log::LevelFilter::Debug,
         node_urls: HashMap::from([
-            (
-                Currency::Iota,
-                vec!["https://api.stardust-mainnet.iotaledger.net".to_string()],
-            ),
+            (Currency::Iota, vec!["https://api.testnet.iotaledger.net".to_string()]),
             (
                 Currency::Eth,
                 vec!["https://ethereum-sepolia-rpc.publicnode.com".to_string()],


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

Previously we updated the sdk to run all regression tests on the iota mainnet. This affected them and started to fail. We need to revert this and run only the send compliment test on the iota mainnet. The rest of the tests should run on the iota testnet. 

We also need to reduce the amount we send since we have only 3 IOTAs on the mainnet. 

## Summary

- Updated the send complement regression test to send a smaller amount of `0.1` so we don't run out of IOTA tokens. But this converts to `0.22` amount. Check it out in the [IOTA Tangle Explorer](https://explorer.iota.org/mainnet/addr/iota1qrh09fqsmen6vdtumzu7szsj5nrectcfkzvxye4k3rpzxupynmhpvf5zpsn).
- Now I config sdk manually for the send compliment example to run it on the iota mainnet. 

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
