### PR TITLE
fix: add dummy feature to make rust-analyzer happy, do not allow deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ repository = "https://github.com/ETOSPHERES-Labs/cawaena-sdk"
 [workspace.lints.rust]
 # Since we are using the deprecation annotation to mark things to remove later, it causes a lot of noise in the problems reported in vscode.
 # Therefore we can allow this lint for now, and simply remove it whenever we need to actually see them.
-deprecated = "allow"
+# deprecated = "allow"
 
 # used for the wasm bindings tests
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -37,6 +37,9 @@ viviswap-swap = []
 # enables billing api calls
 billing = []
 
+# dummy feature to play nicely with dioxus
+server = []
+
 [dependencies]
 aes-gcm = { version = "0.10.3", default-features = false, features = [
     "alloc",


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

This will make `rust-analyzer` completely happy again by adding a dummy feature 💯 That way the `server` feature exists in all linked projects.

Also removed the allow of `deprecated` warning, we should not use deprecated stuff!

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
