### PR TITLE
fic(ci): use explicit replacement instead of env var for pom.xml version

### DIFF
--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -4,7 +4,7 @@ name: deploy-android
 on:
   push:
     branches:
-     - main
+      - main
 
 env:
   CARGO_TERM_COLOR: always
@@ -60,8 +60,9 @@ jobs:
           # create the version string, only supports SNAPSHOT versions for now (add logic to change if release here)
           PUBLISH_VERSION=$(printf "$PKG_VERSION-SNAPSHOT")
 
-          # store the version in PUBLISH_VERSION env used by pom.xml in the next step
-          echo "PUBLISH_VERSION=$PUBLISH_VERSION" >> "$GITHUB_ENV"
+          # replace the version in the pom.xml file before deploying
+          sed -i -e "s|<version>VERSION_TO_REPLACE</version>|<version>$PUBLISH_VERSION</version>|g" pom.xml
+
           echo "Publishing with version $PUBLISH_VERSION"
 
       - name: Publish package

--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -2,6 +2,7 @@ name: deploy-android
 
 # only run this on push to main (eg. after PR merge)
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -2,6 +2,7 @@ name: deploy-swift
 
 # only run this on push to main (eg. after PR merge)
 on:
+  workflow_dispatch:
   push:
     branches:
      - main

--- a/sdk/bindings/android/pom.xml
+++ b/sdk/bindings/android/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cawaena</groupId>
     <artifactId>wallet</artifactId>
-	<version>${env.PUBLISH_VERSION}</version>
+	<version>VERSION_TO_REPLACE</version>
     <packaging>jar</packaging>
     <name>cawaena-sdk-jni</name>
     <description>The SDK java native bindings for use in java based applications and android</description>

--- a/sdk/bindings/android/pom.xml
+++ b/sdk/bindings/android/pom.xml
@@ -53,14 +53,15 @@
                         <configuration>
                             <inlineDescriptors>
                                 <inlineDescriptor>
-                                    <id>native-android</id>
+                                    <id>natives-android</id>
                                     <formats>
                                         <format>jar</format>
                                     </formats>
+									<includeBaseDirectory>false</includeBaseDirectory>
                                     <fileSets>
                                         <fileSet>
                                             <directory>jniLibs/</directory>
-                                            <outputDirectory>native/</outputDirectory>
+                                            <outputDirectory>android/</outputDirectory>
                                         </fileSet>
                                     </fileSets>
                                 </inlineDescriptor>
@@ -68,7 +69,7 @@
                         </configuration>
                     </execution>
 					<execution>
-                        <id>linux-x86_64</id>
+                        <id>linux-x64</id>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
@@ -76,14 +77,15 @@
                         <configuration>
                             <inlineDescriptors>
                                 <inlineDescriptor>
-                                    <id>native-linux-x86_64</id>
+                                    <id>natives-linux</id>
                                     <formats>
                                         <format>jar</format>
                                     </formats>
+									<includeBaseDirectory>false</includeBaseDirectory>
                                     <files>
                                         <file>
 											<source>../../../target/release/libwalletsdk.so</source>
-											<outputDirectory>native/x86_64/linux/</outputDirectory>
+											<outputDirectory>linux/x64/</outputDirectory>
                                         </file>
                                     </files>
                                 </inlineDescriptor>


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

Well it turns out that maven does not really work well when specifying env variable as the version in `pom.xml`. The result is:
- Package is published with the correct version to Maven Central
- But the published `pom.xml` _still has_ the `${env.PUBLISH_VERSION}` as `version` 🤯 

So instead we just do it the real way and use `sed` to replace the version in the file directly 🤞 

(Also made it possible to trigger these jobs manually, makes it easier to test them out 💯 )
(And changed some of the packaging options to make it easier to extract and use the native `.so` files)

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
