### PR TITLE
fix: wasm examples import after crate rename

### DIFF
--- a/sdk/bindings/wasm/examples/01-create_new_user.ts
+++ b/sdk/bindings/wasm/examples/01-create_new_user.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";// Import the WASM module
+import * as wasm from "../pkg/cawaena_sdk_wasm";// Import the WASM module
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/02-onboard_user_via_postident.ts
+++ b/sdk/bindings/wasm/examples/02-onboard_user_via_postident.ts
@@ -1,5 +1,5 @@
 //  Need to do manual verification on postident: https://postident-itu.deutschepost.de/testapp
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/03-create_new_wallet.ts
+++ b/sdk/bindings/wasm/examples/03-create_new_wallet.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/04-migrate_wallet_from_mnemonic.ts
+++ b/sdk/bindings/wasm/examples/04-migrate_wallet_from_mnemonic.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/05-migrate_wallet_from_backup.ts
+++ b/sdk/bindings/wasm/examples/05-migrate_wallet_from_backup.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/06-generate_new_address.ts
+++ b/sdk/bindings/wasm/examples/06-generate_new_address.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/07-get_balance.ts
+++ b/sdk/bindings/wasm/examples/07-get_balance.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/08-create_purchase_request.ts
+++ b/sdk/bindings/wasm/examples/08-create_purchase_request.ts
@@ -1,5 +1,5 @@
 import { debug } from "util";
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/09-onboard_user_via_viviswap.ts
+++ b/sdk/bindings/wasm/examples/09-onboard_user_via_viviswap.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/10-verify_pin.ts
+++ b/sdk/bindings/wasm/examples/10-verify_pin.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/11-reset_pin.ts
+++ b/sdk/bindings/wasm/examples/11-reset_pin.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/12-change_password.ts
+++ b/sdk/bindings/wasm/examples/12-change_password.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/13-send_amount.ts
+++ b/sdk/bindings/wasm/examples/13-send_amount.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/14-get_exchange_rate.ts
+++ b/sdk/bindings/wasm/examples/14-get_exchange_rate.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/16-get_tx_list.ts
+++ b/sdk/bindings/wasm/examples/16-get_tx_list.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 

--- a/sdk/bindings/wasm/examples/17-create_customer.ts
+++ b/sdk/bindings/wasm/examples/17-create_customer.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/18-delete_user.ts
+++ b/sdk/bindings/wasm/examples/18-delete_user.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 async function main() {

--- a/sdk/bindings/wasm/examples/19-get_wallet_tx_list.ts
+++ b/sdk/bindings/wasm/examples/19-get_wallet_tx_list.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 

--- a/sdk/bindings/wasm/examples/20-send_compliment.ts
+++ b/sdk/bindings/wasm/examples/20-send_compliment.ts
@@ -1,4 +1,4 @@
-import * as wasm from "../pkg/cryptpay_sdk_wasm";
+import * as wasm from "../pkg/cawaena_sdk_wasm";
 import { initSdk } from './utils';
 
 // Send compliment example with sender `alice` and receiver `satoshi`

--- a/sdk/bindings/wasm/tsconfig.json
+++ b/sdk/bindings/wasm/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "files": [
-        "pkg/cryptpay_sdk_wasm.d.ts"
+        "pkg/cawaena_sdk_wasm.d.ts"
     ],
 }

--- a/sdk/docs/SDK Configuration/Configuration.md
+++ b/sdk/docs/SDK Configuration/Configuration.md
@@ -83,7 +83,7 @@ Every time the OAuth client refreshes or fetches a new access token for the user
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")

--- a/sdk/docs/SDK Modules/Managing user.md
+++ b/sdk/docs/SDK Modules/Managing user.md
@@ -82,7 +82,7 @@ The `username` should always match the `preferred_username` claim on the JWT `ac
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")
@@ -165,7 +165,7 @@ The access token brings the following safe operations for the SDK:
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")
@@ -257,7 +257,7 @@ Deleting the user is simply deleting the user entity from the local database, wh
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")

--- a/sdk/docs/SDK Modules/Managing wallet.md
+++ b/sdk/docs/SDK Modules/Managing wallet.md
@@ -114,7 +114,7 @@ This does not require any user input except `username`,  `password` and `pin`. B
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")
@@ -190,7 +190,7 @@ This just performs the second step of the create fresh wallet process and needs 
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")
@@ -279,7 +279,7 @@ To restore the backup, the following are required:
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")
@@ -357,7 +357,7 @@ This function just deletes the wallet files and is a one-way function, to be use
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")
@@ -450,7 +450,7 @@ In addition to creating, migrating, backups and initialization, the wallet modul
 === "Typescript"
 
     ```typescript linenums="1"
-    import * as wasm from "../pkg/cryptpay_sdk_wasm";
+    import * as wasm from "../pkg/cawaena_sdk_wasm";
 
     const sdk = await new CawaenaSdk();
     await sdk.setConfig("...")

--- a/sdk/mkdocs.yml
+++ b/sdk/mkdocs.yml
@@ -11,7 +11,7 @@ plugins:
       enable_creation_date: true
   - search
   - typedoc:
-      source: "./bindings/wasm/pkg/cryptpay_sdk_wasm.d.ts"
+      source: "./bindings/wasm/pkg/cawaena_sdk_wasm.d.ts"
       output_dir: "jstsdocs"
       tsconfig: "./bindings/wasm/tsconfig.json"
       options: "./bindings/wasm/typedoc.json"


### PR DESCRIPTION
# Pull Request Template

## Motivation and Context

- Crate was renamed which changes the output name, I never ran the examples and they were still importing the old package!

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
